### PR TITLE
Fix parsing of objectGUIDs containing the byte 5C

### DIFF
--- a/ldap3/protocol/convert.py
+++ b/ldap3/protocol/convert.py
@@ -198,17 +198,10 @@ def prepare_filter_for_sending(raw_string):
     ints = []
     raw_string = to_raw(raw_string)
     while i < len(raw_string):
-        if (raw_string[i] == 92 or raw_string[i] == '\\') and i < len(raw_string) - 2:  # 92 (0x5C) is backslash
-            try:
-                ints.append(int(raw_string[i + 1: i + 3], 16))
-                i += 2
-            except ValueError:  # not an ldap escaped value, sends as is
-                ints.append(92)  # adds backslash
-        else:
-            if str is not bytes:  # Python 3
-                ints.append(raw_string[i])
-            else:  # Python 2
-                ints.append(ord(raw_string[i]))
+        if str is not bytes:  # Python 3
+            ints.append(raw_string[i])
+        else:  # Python 2
+            ints.append(ord(raw_string[i]))
         i += 1
 
     if str is not bytes:  # Python 3

--- a/ldap3/protocol/formatters/validators.py
+++ b/ldap3/protocol/formatters/validators.py
@@ -37,16 +37,6 @@ from ...utils.conv import to_raw, to_unicode, ldap_escape_to_bytes, escape_bytes
 # or a value different from True and False that is a valid value to substitute to the input value
 
 
-def check_backslash(value):
-    if isinstance(value, (bytearray, bytes)):
-        if b'\\' in value:
-            value = value.replace(b'\\', b'\\5C')
-    elif isinstance(value, STRING_TYPES):
-        if '\\' in value:
-            value = value.replace('\\', '\\5C')
-    return value
-
-
 def check_type(input_value, value_type):
     if isinstance(input_value, value_type):
         return True
@@ -315,7 +305,6 @@ def validate_guid(input_value):
             return False
 
     if changed:
-        # valid_values = [check_backslash(value) for value in valid_values]
         if sequence:
             return valid_values
         else:
@@ -359,7 +348,6 @@ def validate_uuid(input_value):
             return False
 
     if changed:
-        # valid_values = [check_backslash(value) for value in valid_values]
         if sequence:
             return valid_values
         else:
@@ -420,7 +408,6 @@ def validate_uuid_le(input_value):
             return False
 
     if changed:
-        # valid_values = [check_backslash(value) for value in valid_values]
         if sequence:
             return valid_values
         else:
@@ -493,7 +480,6 @@ def validate_sid(input_value):
                 changed = True
 
     if changed:
-        # valid_values = [check_backslash(value) for value in valid_values]
         if sequence:
             return valid_values
         else:

--- a/test/testValidators.py
+++ b/test/testValidators.py
@@ -1,8 +1,12 @@
 import unittest
 from datetime import datetime
+from uuid import UUID
 
-from ldap3.protocol.formatters.validators import validate_integer, validate_boolean, validate_bytes, validate_generic_single_value, validate_time, validate_zero_and_minus_one_and_positive_int
+from ldap3.protocol.formatters.validators import validate_integer, validate_boolean, validate_bytes, validate_generic_single_value, validate_time, validate_zero_and_minus_one_and_positive_int, validate_uuid_le
 from ldap3.core.timezone import OffsetTzInfo
+
+from ldap3.protocol.convert import prepare_filter_for_sending
+
 
 class Test(unittest.TestCase):
     def test_int_validator_valid_number(self):
@@ -202,3 +206,40 @@ class Test(unittest.TestCase):
         self.assertTrue(validated)
         validated = validate_zero_and_minus_one_and_positive_int('-2')
         self.assertFalse(validated)
+
+    def test_validate_uuid_le_no_5C(self):
+        uuid_str = '86f66df5-9b0e-4f7d-a6ef-1b897469dcaa'
+        validated = validate_uuid_le(uuid_str)
+        self.assertEqual(validated, UUID(hex=uuid_str).bytes_le)
+
+        uuid_str = '{86f66df5-9b0e-4f7d-a6ef-1b897469dcaa}'
+        validated = validate_uuid_le(uuid_str)
+        self.assertEqual(validated, UUID(hex=uuid_str).bytes_le)
+
+        uuid_str = '86f66df5-9b0e-4f7d-a6ef-1b897469dcaa'
+        validated = validate_uuid_le("\\f5\\6d\\f6\\86\\0e\\9b\\7d\\4f\\a6\\ef\\1b\\89\\74\\69\\dc\\aa")
+        self.assertEqual(validated, UUID(hex=uuid_str).bytes_le)
+
+    def test_validate_uuid_le_5C_no_valid_hex(self):
+        # Issue #894
+        uuid_str = '1f3e2261-b35c-4065-98e3-3c243f695446'
+        validated = validate_uuid_le(uuid_str)
+        self.assertEqual(validated, UUID(hex=uuid_str).bytes_le)
+
+    def test_validate_uuid_le_5C_valid_hex(self):
+        # Issue #1000, but 0x4143 -> AD -> happens to be a valid hex number
+        uuid_str = 'db6ffb06-5c7e-4341-a899-7eda79866582'
+        validated = validate_uuid_le(uuid_str)
+        self.assertEqual(validated, UUID(hex=uuid_str).bytes_le)
+
+    def test_validate_uuid_le_5C_valid_hex_prepared(self):
+        # Issue #1000, prepare_filter_for_sending applied
+        uuid_str = 'db6ffb06-5c7e-4341-a899-7eda79866582'
+        validated = prepare_filter_for_sending(validate_uuid_le(uuid_str))
+        self.assertEqual(validated, UUID(hex=uuid_str).bytes_le)
+
+    def test_validate_uuid_le_5C_outofrange_hex_prepared(self):
+        # Issue #1000, but 0x2D43 -> -C -> happens to be a invalid (negative) hex number
+        uuid_str = 'db6ffb06-5c7e-432d-a899-7eda79866582'
+        validated = prepare_filter_for_sending(validate_uuid_le(uuid_str))
+        self.assertEqual(validated, UUID(hex=uuid_str).bytes_le)


### PR DESCRIPTION
The prepare_filter_for_sending() function contains code for parsing escaped hexadecimal values after ``\`` by using the next two characters. Checking, if they appear to be hex digits and converting them, otherwise adding the ``\`` and the following chars as is.

However, when iterating over any "bytes" object as to_raw() guarantees we have, we do not encounter escaping backslashes. Every backslash we encounter already *is* the character we want to write.
This lead to the following problem: Anytime an objectGUID contains a "5C" at positions 0-13 followed by (in little endian ordering) two byte representations of hexadecimal digits (0x30-0x39, 0x41-0x46, 0x61-0x66, 0x2B, 0x2D, possibly 0x2E?), the algorithm would swallow the 0x5C and parse the two following bytes as hexadecimal of their ASCII representations.
Issues: cannatag/ldap3#589, cannatag/ldap3#762, cannatag/ldap3#1000
A fix attempt was introduced with check_backslash(), which would add a "5C" literal after the original parsed 0x5C backslash, so the problem in prepare_filter_for_sending() was masked for any search attempt. But, every other instance of code which touches GUIDs and is not part of the filter query, would break when applying the "5C" from check_backslash(). Most notably in the MockServer implementation.
Issue #894

This commit fully removes the ``\`` check from prepare_filter_for_sending() and also removes the unused check_backslash(). It also adds some "5C" UUIDs to the validator unit tests which both cover issues #1000 and #894.

Closes cannatag/ldap3#1000